### PR TITLE
fix: Switch to Stadia Maps for better road visibility in light mode

### DIFF
--- a/components/ui/map.tsx
+++ b/components/ui/map.tsx
@@ -45,8 +45,8 @@ function useMap() {
 }
 
 const defaultStyles = {
-  dark: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
-  light: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+  dark: 'https://tiles.stadiamaps.com/styles/alidade_smooth_dark.json',
+  light: 'https://tiles.stadiamaps.com/styles/osm_bright.json',
 }
 
 type MapStyleOption = string | MapLibreGL.StyleSpecification

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,10 +36,11 @@ const productionHeaders = isDev
         value: [
           "default-src 'self'",
           "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com https://www.gstatic.com",
+          "worker-src 'self' blob:",
           "style-src 'self' 'unsafe-inline'",
-          "img-src 'self' data: blob: https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com",
+          "img-src 'self' data: blob: https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com https://tiles.stadiamaps.com",
           "font-src 'self'",
-          "connect-src 'self' https://nominatim.openstreetmap.org https://router.project-osrm.org https://www.google.com https://*.basemaps.cartocdn.com",
+          "connect-src 'self' https://nominatim.openstreetmap.org https://router.project-osrm.org https://www.google.com https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://tiles.stadiamaps.com",
           'frame-src https://www.google.com',
           "object-src 'none'",
           "base-uri 'self'",
@@ -80,6 +81,17 @@ if (!isDev) {
           cacheName: 'openstreetmap-tiles',
           expiration: {
             maxEntries: 100,
+            maxAgeSeconds: 7 * 24 * 60 * 60, // 7 days
+          },
+        },
+      },
+      {
+        urlPattern: /^https:\/\/tiles\.stadiamaps\.com\/.*/i,
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'stadia-tiles',
+          expiration: {
+            maxEntries: 200,
             maxAgeSeconds: 7 * 24 * 60 * 60, // 7 days
           },
         },


### PR DESCRIPTION
CARTO's Positron/Voyager styles were too minimal - roads barely visible. Switched to Stadia Maps which renders all road types clearly:
- Light mode: osm_bright (classic OSM-like appearance)
- Dark mode: alidade_smooth_dark (clean dark theme)

Also updated CSP and PWA caching for tiles.stadiamaps.com.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated default map styling for improved visual presentation
  * Optimized map tile caching to enhance loading performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->