### PR TITLE
fix: apply Prettier formatting to fix CI build

### DIFF
--- a/__tests__/components/ride-comparison-form.test.tsx
+++ b/__tests__/components/ride-comparison-form.test.tsx
@@ -112,7 +112,6 @@ jest.mock('@/lib/popular-routes-data', () => ({
   }),
 }))
 
-
 describe('RideComparisonForm', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/__tests__/lib/alert-evaluation.test.ts
+++ b/__tests__/lib/alert-evaluation.test.ts
@@ -69,7 +69,9 @@ describe('evaluateAndCreateNotifications', () => {
     ;(prisma.priceAlert.update as jest.Mock).mockImplementation(({ where, data }) =>
       Promise.resolve({ id: where.id, ...data })
     )
-    ;(prisma.$transaction as jest.Mock).mockImplementation(async operations => Promise.all(operations))
+    ;(prisma.$transaction as jest.Mock).mockImplementation(async operations =>
+      Promise.all(operations)
+    )
   })
 
   it('returns early when the database is unavailable', async () => {

--- a/__tests__/lib/cache/redis-cache.test.ts
+++ b/__tests__/lib/cache/redis-cache.test.ts
@@ -223,11 +223,7 @@ describe('incrementQuotaCounter', () => {
     // Verify the expireat timestamp is for next midnight UTC
     const expireAt = mockExpireat.mock.calls[0][1] as number
     const now = new Date()
-    const nextMidnight = Date.UTC(
-      now.getUTCFullYear(),
-      now.getUTCMonth(),
-      now.getUTCDate() + 1
-    )
+    const nextMidnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1)
     const expectedExpireAt = Math.floor(nextMidnight / 1000)
 
     // Allow +-60 seconds tolerance for test timing

--- a/__tests__/services/ai-insights.test.ts
+++ b/__tests__/services/ai-insights.test.ts
@@ -264,11 +264,7 @@ describe('AI Insights Service', () => {
 
   describe('getCached integration', () => {
     it('getCached hit path — compute not called — recommendations returned from cache', async () => {
-      const cachedMessages = [
-        'Cached message 1',
-        'Cached message 2',
-        'Cached message 3',
-      ]
+      const cachedMessages = ['Cached message 1', 'Cached message 2', 'Cached message 3']
 
       // Simulate a cache hit — compute is never called
       mockGetCached.mockResolvedValueOnce({ value: cachedMessages, cacheHit: true })

--- a/__tests__/services/ride-comparison.test.ts
+++ b/__tests__/services/ride-comparison.test.ts
@@ -35,7 +35,12 @@ jest.mock('@/lib/cache/redis-cache', () => {
   const clearAll = () => store.clear()
   const prePopulate = (key: string, value: unknown) => store.set(key, value)
 
-  return { getCached: getCachedMock, clearCacheNamespace: clearCacheNamespaceMock, clearAll, prePopulate }
+  return {
+    getCached: getCachedMock,
+    clearCacheNamespace: clearCacheNamespaceMock,
+    clearAll,
+    prePopulate,
+  }
 })
 
 jest.mock('@/lib/database', () => ({

--- a/app/api/compare-rides/route.ts
+++ b/app/api/compare-rides/route.ts
@@ -22,11 +22,7 @@ import { enhanceWithAI } from '@/lib/services/ai-insights'
 import { evaluateAndCreateNotifications } from '@/lib/alert-evaluation'
 import { log, logError } from '@/lib/monitoring'
 import { getRequestId, createResponseHeaders } from '@/lib/api-helpers'
-import type {
-  ComparisonApiResponse,
-  CoordinateComparisonRequest,
-  ServiceType,
-} from '@/types'
+import type { ComparisonApiResponse, CoordinateComparisonRequest, ServiceType } from '@/types'
 
 function mapCompareError(error: CompareServiceErrorCode): {
   status: number

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -62,80 +62,80 @@ async function handleGet(request: NextRequest) {
 
       const [savingsActions, comparisonCount, alertsSet, unreadAlertCount, surgeInsightsRaw] =
         await Promise.all([
-        // Savings from followed recommendations
-        process.env.DATABASE_URL
-          ? prisma.recommendationAction
-              .findMany({
-                where: {
-                  userId,
-                  action: 'FOLLOWED',
-                  estimatedSavings: { not: null },
-                  createdAt: { gte: thirtyDaysAgo },
-                },
-                select: { estimatedSavings: true },
+          // Savings from followed recommendations
+          process.env.DATABASE_URL
+            ? prisma.recommendationAction
+                .findMany({
+                  where: {
+                    userId,
+                    action: 'FOLLOWED',
+                    estimatedSavings: { not: null },
+                    createdAt: { gte: thirtyDaysAgo },
+                  },
+                  select: { estimatedSavings: true },
+                })
+                .catch(() => [])
+            : Promise.resolve([]),
+          // Count of search logs (comparisons)
+          process.env.DATABASE_URL
+            ? prisma.searchLog
+                .count({
+                  where: {
+                    userId,
+                    createdAt: { gte: thirtyDaysAgo },
+                  },
+                })
+                .catch(() => 0)
+            : Promise.resolve(0),
+          // Count of active alerts
+          process.env.DATABASE_URL
+            ? prisma.priceAlert
+                .count({
+                  where: {
+                    userId,
+                    isActive: true,
+                  },
+                })
+                .catch(() => 0)
+            : Promise.resolve(0),
+          process.env.DATABASE_URL
+            ? prisma.alertNotification
+                .count({
+                  where: {
+                    userId,
+                    isRead: false,
+                  },
+                })
+                .catch(() => 0)
+            : Promise.resolve(0),
+          // Surge insights from first saved route's RouteInsights
+          (async () => {
+            if (!process.env.DATABASE_URL) return []
+            const firstSavedRoute = await prisma.savedRoute
+              .findFirst({
+                where: { userId, routeId: { not: null } },
+                select: { routeId: true },
               })
-              .catch(() => [])
-          : Promise.resolve([]),
-        // Count of search logs (comparisons)
-        process.env.DATABASE_URL
-          ? prisma.searchLog
-              .count({
-                where: {
-                  userId,
-                  createdAt: { gte: thirtyDaysAgo },
-                },
+              .catch(() => null)
+            if (!firstSavedRoute?.routeId) return []
+            const insights = await prisma.routeInsights
+              .findFirst({
+                where: { routeId: firstSavedRoute.routeId },
+                select: { surgeProbabilityByHour: true },
               })
-              .catch(() => 0)
-          : Promise.resolve(0),
-        // Count of active alerts
-        process.env.DATABASE_URL
-          ? prisma.priceAlert
-              .count({
-                where: {
-                  userId,
-                  isActive: true,
-                },
-              })
-              .catch(() => 0)
-          : Promise.resolve(0),
-        process.env.DATABASE_URL
-          ? prisma.alertNotification
-              .count({
-                where: {
-                  userId,
-                  isRead: false,
-                },
-              })
-              .catch(() => 0)
-          : Promise.resolve(0),
-        // Surge insights from first saved route's RouteInsights
-        (async () => {
-          if (!process.env.DATABASE_URL) return []
-          const firstSavedRoute = await prisma.savedRoute
-            .findFirst({
-              where: { userId, routeId: { not: null } },
-              select: { routeId: true },
-            })
-            .catch(() => null)
-          if (!firstSavedRoute?.routeId) return []
-          const insights = await prisma.routeInsights
-            .findFirst({
-              where: { routeId: firstSavedRoute.routeId },
-              select: { surgeProbabilityByHour: true },
-            })
-            .catch(() => null)
-          if (!insights?.surgeProbabilityByHour) return []
-          const surgeData = insights.surgeProbabilityByHour as Record<string, number>
-          return Object.entries(surgeData)
-            .map(([hour, probability]) => ({
-              hour: parseInt(hour, 10),
-              probability,
-            }))
-            .filter(s => s.probability > 0.1)
-            .sort((a, b) => b.probability - a.probability)
-            .slice(0, 8)
-        })(),
-      ])
+              .catch(() => null)
+            if (!insights?.surgeProbabilityByHour) return []
+            const surgeData = insights.surgeProbabilityByHour as Record<string, number>
+            return Object.entries(surgeData)
+              .map(([hour, probability]) => ({
+                hour: parseInt(hour, 10),
+                probability,
+              }))
+              .filter(s => s.probability > 0.1)
+              .sort((a, b) => b.probability - a.probability)
+              .slice(0, 8)
+          })(),
+        ])
 
       const totalSavings = savingsActions.reduce((sum, a) => sum + (a.estimatedSavings ?? 0), 0)
 

--- a/lib/services/recommendations.ts
+++ b/lib/services/recommendations.ts
@@ -322,7 +322,9 @@ export async function generateRecommendations(
       }
 
       // Limit to 3 recommendations, sorted by confidence
-      const sortedRecs = [...recommendations].sort((a, b) => b.confidence - a.confidence).slice(0, 3)
+      const sortedRecs = [...recommendations]
+        .sort((a, b) => b.confidence - a.confidence)
+        .slice(0, 3)
 
       const result: RecommendationOutput = { recommendations: sortedRecs }
 

--- a/lib/services/ride-comparison.ts
+++ b/lib/services/ride-comparison.ts
@@ -164,7 +164,6 @@ const WAYMO_SERVICE_AREAS = {
   },
 }
 
-
 function kmToMiles(km: number): number {
   return km * 0.621371
 }
@@ -538,7 +537,10 @@ async function geocodeWithCache(address: string): Promise<Coordinates> {
         )
       }
 
-      return [parseFloat(data[0].lon) as Longitude, parseFloat(data[0].lat) as Latitude] as Coordinates
+      return [
+        parseFloat(data[0].lon) as Longitude,
+        parseFloat(data[0].lat) as Latitude,
+      ] as Coordinates
     }
   )
 


### PR DESCRIPTION
## Summary

- Applied Prettier formatting to 9 files that were causing the CI `format:check` step to fail
- All quality checks now pass: typecheck, lint, format, tests (357 passing), and build

## Root Cause

The CI pipeline runs `npm run quality` which includes `prettier --check .`. Nine files had formatting inconsistencies (whitespace, trailing commas, line wrapping) that caused the check to fail with exit code 1.

## Files Changed

- `__tests__/components/ride-comparison-form.test.tsx`
- `__tests__/lib/alert-evaluation.test.ts`
- `__tests__/lib/cache/redis-cache.test.ts`
- `__tests__/services/ai-insights.test.ts`
- `__tests__/services/ride-comparison.test.ts`
- `app/api/compare-rides/route.ts`
- `app/api/dashboard/route.ts`
- `lib/services/recommendations.ts`
- `lib/services/ride-comparison.ts`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 357 tests passing
- [x] `npm run build` — production build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and structure consistency across test suites and service modules.

* **Bug Fixes**
  * Enhanced dashboard endpoint error handling to ensure graceful degradation when database operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->